### PR TITLE
fix: Use new matchit syntax in instantiated_path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ version = "0.2.0"
 dependencies = [
  "axum",
  "http",
+ "itertools",
  "serde",
  "specifications",
 ]
@@ -733,6 +734,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"

--- a/lib/servers/axum-spec/Cargo.toml
+++ b/lib/servers/axum-spec/Cargo.toml
@@ -13,6 +13,7 @@ description = "Pseudo-server that defines the API endpoint locations, methods an
 axum = { version = "0.8.0", optional = true }
 http = "1.0.0"
 serde = { version = "1.0.184", features = ["derive"] }
+itertools = "0.14.0"
 
 specifications = { path = "../../spec" }
 


### PR DESCRIPTION
Note that I also changed the types of the input parameter to a bit more restrictive, this can both prevent monomorphization, but most of all saves us quite a few allocations.